### PR TITLE
Minor Fixes in image util path processing

### DIFF
--- a/notebooks/BoneawareAI.ipynb
+++ b/notebooks/BoneawareAI.ipynb
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -197,7 +197,6 @@
     }
    ],
    "source": [
-    "%pip install pyyaml==5.4.1\n",
     "%pip install boto3\n",
     "%pip install configparser\n",
     "%pip install torch"
@@ -243,14 +242,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.append('../src')  # Add the 'src' folder to Python's module search path\n",
-    "sys.path.append('../datasets')  # Add the 'datasets' folder to Python's module search path\n",
-    "sys.path.append('../notebooks')  # Add the 'notebooks' folder to Python's module search path"
+    "sys.path.append('src')  # Add the 'src' folder to Python's module search path\n",
+    "sys.path.append('datasets')  # Add the 'datasets' folder to Python's module search path\n",
+    "sys.path.append('notebooks')  # Add the 'notebooks' folder to Python's module search path"
    ]
   },
   {
@@ -375,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -388,7 +387,7 @@
    ],
    "source": [
     "\n",
-    "data_dir = \"../datasets/MURA-v1.1\"\n",
+    "data_dir = \"datasets/MURA-v1.1\"\n",
     "batch_size = 32\n",
     "\n",
     "# Load training and validation data\n",
@@ -452,13 +451,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "#16 minutes to confirm on local, does not need to run as you can always use the dataset to confirm as well\n",
-    "#confirm_images_and_labels(train_loader, \"train\")\n",
-    "#confirm_images_and_labels(valid_loader, \"valid\")"
+    "#confirm_images_and_labels(train_dataset, \"train\")\n",
+    "#confirm_images_and_labels(valid_dataset, \"valid\")"
    ]
   },
   {

--- a/src/image_utils.py
+++ b/src/image_utils.py
@@ -70,7 +70,8 @@ class MURADataset(Dataset):
 
         # Get the image path
         img_path = self.image_df.iloc[original_idx]["image_path"]
-        relative_img_path = os.path.relpath(img_path, start=self.root_dir.split('/')[-1])
+        rel_path_prefix = '/'.join(self.root_dir.split("/")[-2:]) #extract datasets/MURA-v1.1 prefix
+        relative_img_path = os.path.relpath(img_path, start=rel_path_prefix)
         full_img_path = os.path.normpath(os.path.join(self.root_dir, relative_img_path))
 
         # Determine dataset type for label lookup


### PR DESCRIPTION
# Description
I noticed that when I was running the `BoneawareAI.ipynb` residing in `notebooks/` directory in colab, there were a couple bugs I noticed in the notebook as well as in the path processing of `image_utils.py`. This PR aims to put those fixes. I'm not sure if these will work locally though ....

# Changes Made
* Updated `sys.path.append` to add `src`, `notebooks`, `datasets` directory without the `../` relative path syntax
* Updated `confirm_img_and_labels` function calls to take in the `train_dataset` and `valid_dataset` objects rather than the DataLoader
* Updated determination of the root dir prefix to extract the relpath of within `image_utils.py`

# Testing
* Ran in Colab and verified cells work