### PR TITLE
Minor Directory Fixes

### DIFF
--- a/notebooks/BoneawareAI.ipynb
+++ b/notebooks/BoneawareAI.ipynb
@@ -407,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -429,10 +429,15 @@
     "from data_loader import download_dataset\n",
     "from constants import DATASETS_FOLDER, MURA_DATASET\n",
     "from helpers.utils import unzip_file\n",
-    "# Define the parent directory and dataset path\n",
-    "parent_dir = os.path.abspath(os.path.join(os.getcwd(), \"..\"))  # Go to the parent directory\n",
-    "datasets_folder = os.path.join(parent_dir, DATASETS_FOLDER)   # Define datasets folder in the parent directory\n",
-    "dataset_path = os.path.join(datasets_folder, MURA_DATASET)    # Full path to the dataset file\n",
+    "\n",
+    "if (isLocal):\n",
+    "    # Define the parent directory and dataset path\n",
+    "    parent_dir = os.path.abspath(os.path.join(os.getcwd(), \"..\"))  # Go to the parent directory\n",
+    "    datasets_folder = os.path.join(parent_dir, DATASETS_FOLDER)   # Define datasets folder in the parent directory\n",
+    "    dataset_path = os.path.join(datasets_folder, MURA_DATASET)    # Full path to the dataset file\n",
+    "else:\n",
+    "    datasets_folder = os.path.join(GOOGLE_DRIVE_PATH, DATASETS_FOLDER) # Define datasets folder in the parent directory\n",
+    "    dataset_path = os.path.join(datasets_folder, MURA_DATASET) # Full path to the dataset file\n",
     "\n",
     "# Ensure the datasets folder exists\n",
     "os.makedirs(datasets_folder, exist_ok=True)\n",
@@ -449,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -467,8 +472,11 @@
     }
    ],
    "source": [
+    "if (isLocal):\n",
+    "    data_dir = \"../datasets/MURA-v1.1\"\n",
+    "else:\n",
+    "    data_dir = os.path.join(datasets_folder, 'MURA-v1.1')\n",
     "\n",
-    "data_dir = \"../datasets/MURA-v1.1\"\n",
     "batch_size = 32\n",
     "\n",
     "# Load training and validation data\n",

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -7,6 +7,7 @@ from helpers.utils import unzip_file
 
 def download_dataset(file, output_folder):
     download_file_from_s3(BONEAWAREAI_S3_BUCKET, file, output_folder)
+    zip_file_path = os.path.join(output_folder, file)
 
-    if zipfile.is_zipfile(file):
-        unzip_file(os.path.join(output_folder, file))
+    if zipfile.is_zipfile(zip_file_path):
+        unzip_file(zip_file_path)


### PR DESCRIPTION
**Context**
When I was testing latest notebook, I noticed some issues with directory paths being referenced when running in colab. 

**Changes Made**
* Add `isLocal` gating to correctly set paths for local and colab development
* Corrected `is_zip_file` function usage by passing in whole file path instead of just the file name

**Testing Plan**
* Ran in colab
* Local route unaltered b/c of gating